### PR TITLE
Fix page(0) and any case where current_page is < 1

### DIFF
--- a/lib/kaminari/neo4j/paginated.rb
+++ b/lib/kaminari/neo4j/paginated.rb
@@ -14,7 +14,7 @@ module Kaminari
 
       def initialize(source, current_page, per_page = nil)
         self.source = source
-        self.current_page = (current_page || 1).to_i
+        self.current_page = current_page == 0 ? 1 : (current_page || 1).to_i
         self.per_page = (per_page || default_per_page).to_i
       end
 

--- a/lib/kaminari/neo4j/paginated.rb
+++ b/lib/kaminari/neo4j/paginated.rb
@@ -14,7 +14,8 @@ module Kaminari
 
       def initialize(source, current_page, per_page = nil)
         self.source = source
-        self.current_page = current_page == 0 ? 1 : (current_page || 1).to_i
+        self.current_page = (current_page || 1).to_i
+        self.current_page = 1 if self.current_page < 1
         self.per_page = (per_page || default_per_page).to_i
       end
 


### PR DESCRIPTION
Calling `page(0)` will trigger a cypher error due to the logic here.  For instance, if the `per_page` is set to 10, then `page(0)` will attempt to create a param called `{skip_-10}` which is a syntax error and will attempt to skip -10, which is also an error.  This fixes that special case and any case where `current_page` is < 1.
