### PR TITLE
`model` didn't exist.  Delegate to `source` to fix

### DIFF
--- a/lib/kaminari/neo4j/criteria_methods.rb
+++ b/lib/kaminari/neo4j/criteria_methods.rb
@@ -3,7 +3,8 @@ module Kaminari
     module CriteriaMethods
       include Kaminari::PageScopeMethods
 
-      delegate :default_per_page, :max_per_page, :max_pages, :to => :model
+      delegate :model, to: :source
+      delegate :default_per_page, :max_per_page, :max_pages, to: :model
 
       def entry_name
         model.model_name.human.downcase


### PR DESCRIPTION
I'm not sure why this happened all of the sudden.  Was causing `page_entries_info` not to work.  See this StackOverflow question:

http://stackoverflow.com/questions/2601265/link-to-not-working-in-script-console
