### PR TITLE
Update readme to mention how to require gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Adds [neo4j](https://github.com/neo4jrb/neo4j) support to [kaminari](https://git
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'kaminari-neo4j'
+gem 'kaminari-neo4j', require: 'kaminari/neo4j'
 ```
 
 And then execute:


### PR DESCRIPTION
The main entry point of this gem is actually within `lib/kaminari/neo4j.rb` which requires us to `require 'kaminari/neo4j'`. This PR just adds that to the readme so that it's clear.
