### PR TITLE
Create Bundler-friendly file for loading gem

### DIFF
--- a/lib/kaminari-neo4j.rb
+++ b/lib/kaminari-neo4j.rb
@@ -1,0 +1,1 @@
+require "kaminari/neo4j"


### PR DESCRIPTION
Alternatively...since this gem is named `kaminari-neo4j`, Bundler tries to find a file in the `lib` directory called `kaminari-neo4j.rb`. We can create this file to load the gem and avoid having to manually require it.
